### PR TITLE
Add Claude rules layer for Parabula Next

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,380 @@
+# CLAUDE.md — Parabula Next
+
+הקובץ הזה הוא נקודת הכניסה של Claude Code לריפו Parabula Next.
+קרא אותו לפני כל פעולה. הוא לא מחליף את `PROJECT_RULES.md` — הוא משלים אותו.
+
+---
+
+## 1. זהות הפרויקט
+
+**Parabula Next** הוא מערכת ארוכת טווח לייצור, ניהול, ותצוגה של דפי עבודה במתמטיקה בעברית RTL.
+
+### המוצר המרכזי
+דפי עבודה איכותיים להדפסה ב-A4 — HTML + CSS + SVG + MathJax.
+לא אפליקציה דיגיטלית. לא אתר. **דפי עבודה להדפסה.**
+
+### שכבות התמיכה
+- **תצוגת נייח:** סקירה, עריכה, ניווט, בדיקה — לא תחליף לדפי ההדפסה
+- **תצוגת נייד:** צפייה, ניווט, הדפסה — לא תחליף לדפי ההדפסה
+- **CI/CD:** בדיקות, audit, פרסום — שמירה על שלמות
+
+### יעד סופי
+אפליקציה/ספרייה שמציגה את כל הדפים הקיימים כמו ספר/חוברת דיגיטלית נוחה מאוד —
+עם ניווט נוח, תצוגה מיטבית, הדפסה קלה, וגישה לפי נושא/כיתה/מיומנות.
+
+### מה Yaniv עושה
+מביא חומרי לימוד (PDF, תמונות, טקסט), מעביר אותם לדפי HTML מאורגנים, ומוסיף אותם למערכת.
+**המערכת חייבת לתמוך בהמשך במאות ואלפי דפי עבודה.**
+
+---
+
+## 2. עקרון על — מה לא לגעת בו
+
+```
+קבצים מוגנים — אסור לשנות ללא אישור מפורש של Yaniv:
+
+עמוד-N.html          ← תוכן חינוכי קנוני (כל 95 הדפים)
+styles/a4-base.css   ← בסיס A4 בלתי ניתן לשינוי
+meta/topics.json     ← עמוד שדרה של מטא-דאטה
+sources/legacy/*     ← ארכיון לשימור בלבד
+sources/backups/*    ← גיבויים לשימור בלבד
+STATE/backup_*       ← גיבויי מצב
+meta/backup/*        ← גיבויי מטא-דאטה
+```
+
+---
+
+## 3. מקורות אמת — קרא תמיד לפני שינויים
+
+קרא לפי הסדר הזה בתחילת כל שיחה:
+
+1. `PROJECT_RULES.md` — מקור האמת הראשי (**חובה**)
+2. `STATE/LIVE_STATUS.md` — תמונת מצב חיה קצרה (**חובה**)
+3. `STATE/ARCHITECTURE_MAP.md` — מפת שכבות (**כדאי**)
+4. `STATE/PROJECT_CONTINUITY.md` — רצף עבודה בין שיחות (**כדאי**)
+
+אם יש סתירה בין מסמכים — `PROJECT_RULES.md` + `STATE/LIVE_STATUS.md` גוברים.
+
+---
+
+## 4. מבנה הריפו — מה קיים
+
+### שכבת תוכן קנונית
+```
+עמוד-N.html                    ← 95 דפי עבודה A4 (שורש הריפו)
+styles/pages/עמוד-N.css        ← CSS ייעודי לכל דף
+styles/a4-base.css             ← בסיס CSS משותף + print CSS
+styles/topics/pythagoras.css   ← CSS משותף לנושא (נטען ב-@import)
+```
+
+### שכבת מטא-דאטה
+```
+meta/topics.json        ← מקור אמת של נושאים ודפים (95 דפים, 7 נושאים)
+mobile-topics.json      ← עותק נפרד לאפליקציית הנייד (חייב להיות מסונכרן!)
+schemas/                ← schemas של מטא-דאטה
+```
+
+### שכבת גישה (access surfaces)
+```
+preview/app.html        ← Hub — שער כניסה לכל המסכים
+preview/index.html      ← Preview Reader (נייח, dark sidebar + iframe)
+preview/topics.html     ← דפדוף לפי נושאים
+preview/all-pages.html  ← כל הדפים עם חיפוש וסינון
+preview/print.html      ← מרכז הדפסה
+preview/server.mjs      ← שרת מקומי, port 5179, live-reload SSE
+
+mobile-app.html         ← אפליקציית נייד ראשית (PWA)
+mobile-app.js           ← לוגיקה: fetch mobile-topics.json, iframe, scale
+mobile-app.css          ← עיצוב
+mobile-app.webmanifest  ← PWA manifest
+mobile-app-install.html ← עמוד התקנה
+
+preview/phone.*         ← legacy/compat — לא הנתיב הקנוני לנייד
+```
+
+### שכבת אוטומציה
+```
+scripts/verify.mjs              ← בדיקת מבנה בסיסית
+scripts/recovery-audit.mjs      ← audit שלמות הריפו
+scripts/validate-access-layer.mjs ← בדיקת קבצים קנוניים
+scripts/audit-preview-overlaps.mjs ← בדיקת כפילויות
+scripts/doctor.mjs              ← מריץ כל הבדיקות ברצף
+scripts/new-page.mjs            ← ⚠️ שבור — קורא ל-/api/toc שלא קיים בשרת
+scripts/sync-rules.mjs          ← סנכרון כללים
+```
+
+### שכבת בדיקות
+```
+tests/contracts/root-pages.test.mjs       ← בדיקות בסיסיות
+tests/a4-pages.rules.test.mjs             ← מבנה, ניווט, נושאים
+tests/a4-numbering-ui.rules.test.mjs      ← badge numbering
+tests/preview.rules.test.mjs              ← preview rules
+tests/topic-pages.*.test.mjs              ← topic pages
+```
+
+### שכבת CI
+```
+.github/workflows/deploy-pages.yml         ← build + test + deploy ל-GitHub Pages
+.github/workflows/recovery-audit.yml       ← audit בכל push
+.github/workflows/preview-guard.yml        ← guard preview
+.github/workflows/repository-health.yml    ← health check
+```
+
+---
+
+## 5. כיצד עובדת A4 / הדפסה
+
+```css
+/* עיקרי מ-styles/a4-base.css */
+.a4-page {
+  width: 210mm;
+  height: 297mm;
+  overflow: hidden;           /* לא auto! */
+  padding: 10mm 18mm;
+}
+
+@media print {
+  @page { size: A4; margin: 0; }
+  .a4-page { overflow: visible; box-shadow: none; margin: 0; }
+  .preview-nav { display: none; }
+}
+```
+
+**כללים קריטיים להדפסה:**
+- A4 = 210mm × 297mm בדיוק — לא לשנות
+- `overflow: hidden` במסך, `overflow: visible` בהדפסה
+- אין `overflow: auto` — אסור בהחלט
+- `@page margin: 0` — גיליון ללא שוליים
+- `-webkit-print-color-adjust: exact` — שמירת צבעים
+- גופן Rubik + MathJax טוענים מ-CDN — הדפסה ללא אינטרנט לא תעבוד מיטבית
+
+---
+
+## 6. כיצד עובד מבנה דף עבודה
+
+כל `עמוד-N.html` חייב להכיל בדיוק:
+
+```html
+<nav class="preview-nav">               ← ניווט (נסתר בהדפסה)
+  <div class="preview-nav-top">
+    <div class="nav-side"><a class="nav-link" href="...">הקודם</a></div>
+    <div class="nav-meta">נושא — עמוד X / Y</div>
+    <div class="nav-side"><a class="nav-link" href="...">הבא</a></div>
+  </div>
+  <div class="preview-nav-topics">
+    <a class="topic-link" href="...">נושא א</a>
+    <a class="topic-link is-active" href="..." aria-current="page">נושא ב</a>
+  </div>
+</nav>
+
+<main class="a4-page page-N [topic-class]">
+  <header class="header-container">
+    <h1 class="page-title">שם הנושא</h1>
+    <div class="page-number">X</div>    ← X = מספר בתוך הנושא (לא גלובלי)
+  </header>
+  <div class="question-block">
+    <!-- תוכן הדף -->
+  </div>
+</main>
+```
+
+**חוקים קשיחים:**
+- `page-number` = מספר בתוך הנושא (לא מספר הקובץ!)
+- `<title>` = `עמוד X — שם הנושא`
+- אפס inline CSS (`style="..."` או `<style>` אסורים)
+- כל CSS ב-`styles/pages/עמוד-N.css` בלבד
+- MathJax: `\(...\)` inline, `$$...$$` display — **לא `$...$`**
+- RTL בכל מקום; LTR רק ב-CSS (`direction: ltr; unicode-bidi: isolate`)
+
+---
+
+## 7. כיצד עובדת גרפיקה מתמטית
+
+**כלים קיימים ומאושרים:**
+
+| כלי | שימוש |
+|---|---|
+| MathJax 3 | כל הנוסחאות המתמטיות |
+| SVG inline | גיאומטריה, משולשים, מקביליות, שרטוטים |
+| CSS coordinate-system | ציר קואורדינטות (440px × 440px, grid 22px) |
+| CSS background-image | נייר משבצות לאזורי כתיבה |
+
+**כללי SVG:**
+```css
+vector-effect: non-scaling-stroke;   /* חובה בכל stroke */
+shape-rendering: geometricPrecision; /* חובה ב-SVG גיאומטרי */
+```
+
+**רמת איכות נדרשת:**
+- גרפים ברמת ספרי לימוד — לא screenshots, לא blurry
+- כל SVG חייב להיות vector — לא raster images
+- גיאומטריה: קווים נקיים, label מיקום מדויק, זווית ישרה עם ריבוע
+- קואורדינטות: grid 22px, arrows, labels מחוץ לציר
+
+**מה חסר לעתיד (לא לייצר עכשיו — לתכנן):**
+- כלי לגרפי פונקציות (פרבולה, קו ישר, פונקציה עלייה/ירידה)
+- templates לסוגי דף שונים
+
+---
+
+## 8. כיצד עובד הנייד
+
+**הנתיב הקנוני:** `mobile-app.html` + `mobile-app.js` + `mobile-app.css`
+
+**איך `mobile-app.js` עובד:**
+1. מבצע `fetch('./mobile-topics.json')` — **לא** `meta/topics.json`!
+2. בונה רשימת נושאים ודפים
+3. מציג דף נבחר ב-iframe עם scale transform
+4. מסיר `.preview-nav` בתוך ה-iframe (ניווט מובנה)
+
+**⚠️ בעיה קריטית ידועה:**
+`mobile-topics.json` הוא עותק **מוקפא** של `meta/topics.json` מ-19.03.2026.
+אם יוסיפו דפים ל-`meta/topics.json` — חייבים לעדכן גם את `mobile-topics.json`.
+**עדיין אין סנכרון אוטומטי.**
+
+**נתיב לגאצי:** `preview/phone.*` — קיים אבל לא הנתיב הרשמי.
+
+---
+
+## 9. פקודות זמינות
+
+```bash
+npm run preview          # שרת מקומי http://127.0.0.1:5179/preview
+npm test                 # בדיקות חוזה (tests/contracts/)
+npm run verify           # בדיקת מבנה בסיסית
+npm run validate:access  # בדיקת קבצים קנוניים
+npm run rules:sync       # סנכרון כללים
+
+# ⚠️ שבור כרגע:
+npm run page:new         # קורא ל-/api/toc שלא קיים בשרת
+```
+
+**להרצת doctor מלא:**
+```bash
+node scripts/doctor.mjs
+```
+
+---
+
+## 10. תהליך עבודה מחייב
+
+```
+לימוד → כללים → תוכנית → ביצוע קטן → בדיקה → תיעוד
+```
+
+לפני **כל** ביצוע גדול:
+1. קרא `PROJECT_RULES.md` + `STATE/LIVE_STATUS.md`
+2. הצג: קבצים שיושפעו, סיכונים, מה ייחשב הצלחה
+3. קבל אישור מ-Yaniv
+4. בצע בשינויים קטנים
+5. הרץ `npm test` + `npm run verify`
+6. תעד ב-STATE/
+
+**אין להתחיל תיקוני קוד לפני שיש כללי עבודה מסודרים.**
+
+---
+
+## 11. מה אסור בהחלט
+
+```
+git add .               ← אסור — רק git add לקבצים ספציפיים
+git push --force        ← אסור
+git reset --hard        ← אסור ללא אישור מפורש
+git rebase              ← אסור ללא אישור מפורש
+rm -rf                  ← אסור
+מחיקת קבצים legacy/backup ← אסור
+שינוי עמוד-N.html       ← אסור ללא אישור מפורש
+שינוי styles/a4-base.css ← אסור ללא אישור מפורש
+יצירת fake buttons       ← אסור
+יצירת placeholder UI     ← אסור
+demo content             ← אסור
+כתיבה מחדש של מה שעובד  ← אסור
+```
+
+---
+
+## 12. בעיות ידועות (שצריכות תיקון — לא פתרו עדיין)
+
+| בעיה | קובץ | חומרה |
+|---|---|---|
+| `new-page.mjs` קורא ל-`/api/toc` שלא קיים בשרת | `scripts/new-page.mjs:448` | קריטי |
+| `Puppeteer` לא ב-`package.json` | `package.json` | קריטי |
+| `mobile-topics.json` מוקפא מ-19.03.2026 | `mobile-topics.json` | קריטי |
+| `preview/print.html` עם `<style>` inline | `preview/print.html:9` | בינוני |
+| `preview/index.html` עם `<style>` inline | `preview/index.html:7` | בינוני |
+| שני Service Workers (`sw.js` + `preview/sw.js`) | שורש + preview/ | בינוני |
+| `docs/` — עותק סטטי שאולי לא מעודכן | `docs/` | נמוך |
+| ניווט הקודם/הבא קשיח ב-HTML | כל 95 דפים | נמוך (ידוע, מכוון) |
+
+---
+
+## 13. חזון עתידי — ספר/ספרייה דיגיטלית
+
+### המטרה
+כל הדפים הקיימים מוצגים כמו ספר/חוברת דיגיטלית נוחה:
+- דפדוף נוח בין דפים ונושאים
+- חיפוש לפי נושא, כיתה, מיומנות, סוג משימה
+- הדפסה קלה (דף בודד / חוברת שלמה)
+- ניתן להרחיב לאלפי דפים בעתיד
+
+### מטא-דאטה עתידי (לא לממש עכשיו — לתכנן)
+```json
+{
+  "topics": [{
+    "name": "משפט פיתגורס",
+    "grade": "ט",
+    "pages": [{
+      "number": 9,
+      "file": "עמוד-9.html",
+      "skill": "חישוב צלע חסרה",
+      "difficulty": "בסיסי",
+      "worksheetType": "תרגול"
+    }]
+  }]
+}
+```
+
+### כיצד חומרים חדשים יתווספו (תהליך מוצע)
+1. Yaniv מביא חומר (PDF / תמונה / טקסט)
+2. Claude בונה HTML מ-template ייעודי לנושא
+3. SVG גיאומטרי / גרפי נוצר inline
+4. MathJax מוסיף למשוואות
+5. סקריפט מייצר דף + CSS + מעדכן meta/topics.json + mobile-topics.json
+6. CI מריץ tests + deploys
+
+---
+
+## 14. GitHub Pages
+
+```
+URL:        https://yanivmizrachiy.github.io/parabula-next/
+Workflow:   .github/workflows/deploy-pages.yml
+תהליך:     npm test → npm run verify → npm run build (Vite) → copy assets → deploy dist/
+base path:  /parabula-next/ (מוגדר ב-vite.config.js)
+```
+
+**דף ה-mobile app הציבורי:** `mobile-app.html`
+**דף ההתקנה הציבורי:** `mobile-app-install.html`
+
+---
+
+## 15. תכנות Claude Code לריפו זה
+
+### פקודות מומלצות ל-`.claude/commands/` (עדיין לא נוצרו)
+- `/audit` — הרץ doctor + recovery-audit + overlap-audit
+- `/worksheet` — הוסף דף עבודה חדש
+- `/print` — בדוק print CSS + A4 overflow
+- `/mobile` — בדוק mobile-app.* + sync
+- `/rules` — עדכן PROJECT_RULES.md
+- `/verify` — הרץ npm test + verify + validate:access
+
+### סוכנים מומלצים (עדיין לא נוצרו)
+- `a4-print-guardian` — בדיקת A4 overflow בכל הדפים
+- `repo-cartographer` — מיפוי הריפו לפני כל שיחה
+- `source-of-truth-guardian` — בדיקת עמידה בכללים
+- `math-graphics-reviewer` — הערכת SVG + MathJax quality
+
+---
+
+_CLAUDE.md נוצר: 2026-05-12_
+_לא נוגע בדפי עבודה, CSS הדפסה, mobile-app.*, package.json, או קוד אפליקציה._

--- a/PROJECT_RULES.md
+++ b/PROJECT_RULES.md
@@ -463,3 +463,107 @@ This map is intentionally limited to files that are actually present on `main`.
 - The equations print/PDF route is browser-driven through `preview/print.html?topic=%D7%9E%D7%A9%D7%95%D7%95%D7%90%D7%95%D7%AA&autoselect=topic`.
 - Do not mark this family fully complete unless real preview, phone viewing, and browser print / Save as PDF have been checked.
 
+
+<!-- YANIV_CLAUDE_RULES_LAYER_START -->
+
+## Claude / AI rules layer — Yaniv requirements
+
+This section is the mandatory rules layer for Claude Code and any AI assistant working on this repository.
+
+### Product identity
+
+Parabula Next is a long-term Hebrew RTL printable math worksheet production system.
+
+The core product is high-quality A4 printable worksheets. Desktop and mobile views are support layers for preview, review, navigation, editing, and printing. They are not a replacement for print-quality worksheets.
+
+### Long-term goal
+
+The repository must evolve into a comfortable worksheet book/library application that presents all existing printable pages like a digital textbook/workbook, while preserving A4 print quality and enabling future expansion to hundreds or thousands of worksheets.
+
+Future worksheets must be organized by topic, grade, skill, worksheet type, and learning sequence.
+
+### Preservation rules
+
+- Preserve all existing worksheet pages.
+- Preserve Hebrew RTL correctness.
+- Preserve A4 print quality.
+- Preserve what already works well.
+- Do not rewrite working systems just because they can be rewritten.
+- Do not remove legacy files without evidence and explicit approval.
+- Do not introduce demo content, fake buttons, fake flows, or placeholder behavior.
+
+### Editing architecture rules
+
+Future worksheet creation and correction must be fast and safe.
+
+Prefer clear separation between:
+
+1. HTML/content structure
+2. CSS styling
+3. print-specific CSS
+4. mobile/preview CSS
+5. JavaScript behavior
+6. worksheet/task data
+7. reusable math/diagram components
+8. validation scripts
+9. build/export/print logic
+
+CSS should be separated from HTML where practical to improve editing, reuse, and maintainability.
+
+### Math graphics quality
+
+Math graphics must aim for textbook/workbook quality.
+
+Graphs, coordinate systems, diagrams, illustrations, SVG/vector graphics, MathJax notation, typography, and layout must be precise, printable, visually consistent, and easy to maintain.
+
+Use stronger tools only when they clearly improve quality, print, editing speed, reuse, or maintainability. Do not replace a good working tool just because a newer tool exists.
+
+### Repository organization
+
+The repo should be organized with clear folders and meaningful filenames. If the structure needs improvement, propose staged reorganization first. Do not break existing pages or workflows.
+
+### Automation and scripting policy
+
+Safe automation only. Scripts may read, validate, and report by default.
+
+Destructive operations require explicit approval from Yaniv.
+
+Forbidden without explicit approval:
+
+- deleting files
+- force push
+- git add .
+- changing protected worksheet source files
+- changing A4/print core files
+- changing mobile runtime files
+- rewriting architecture
+- removing legacy files
+- committing reports, temp files, backups, logs, or secrets
+
+### Pre-execution requirements
+
+Before any non-trivial implementation:
+
+1. State which files will be affected.
+2. State the risks.
+3. State the success criteria.
+4. Get explicit approval from Yaniv.
+5. Execute in small steps.
+6. Test/verify after each meaningful change.
+7. Document the result in STATE/ or the relevant source-of-truth file when needed.
+
+### Mandatory workflow order
+
+Learn -> Rules -> Plan -> Small Execute -> Test -> Document
+
+Skipping any step violates this file's authority.
+
+### Relationship between CLAUDE.md and PROJECT_RULES.md
+
+CLAUDE.md is the Claude Code entry point for this repository.
+
+PROJECT_RULES.md remains the governing source of truth. If CLAUDE.md and PROJECT_RULES.md conflict, PROJECT_RULES.md wins.
+
+Both files must be kept synchronized when rules change.
+
+<!-- YANIV_CLAUDE_RULES_LAYER_END -->


### PR DESCRIPTION
Draft PR for adding Claude Code project memory and rules layer to Parabula Next.

Includes:
- CLAUDE.md as Claude Code entry point for this repo.
- PROJECT_RULES.md rules layer for printable Hebrew RTL A4 worksheet workflow.
- No worksheet source changes.
- No mobile-app changes.
- No package.json changes.
- No print CSS changes.
- No main push.

This PR should be reviewed before merge. Do not start code fixes from this PR yet.