### PR TITLE
Add Claude next command for Parabula Next

### DIFF
--- a/.claude/commands/next.md
+++ b/.claude/commands/next.md
@@ -1,0 +1,43 @@
+Return the one safest next action for Parabula Next.
+
+This command is planning-only by default.
+
+Before answering, read:
+- CLAUDE.md
+- PROJECT_RULES.md
+- relevant .claude/commands and .claude/agents files only if needed
+
+Do not edit files.
+Do not run tests unless explicitly asked.
+Do not run git add.
+Do not commit.
+Do not push.
+Do not delete.
+Do not reset.
+Do not rebase.
+
+Your answer must be short and in Hebrew.
+
+Required output:
+
+1. Current verified status
+2. The one safest next action
+3. Why this action matters
+4. Which files would be affected
+5. Whether protected files are involved
+6. Risk level: low / medium / high
+7. Exact approval needed from Yaniv before execution
+8. What success will look like
+9. What not to do yet
+
+Rules:
+- Recommend only one next action.
+- Do not give a long roadmap.
+- Do not start implementation.
+- Do not propose broad refactoring.
+- Prefer read-only audit or small documentation/tooling steps before code changes.
+- Preserve printable A4 worksheet quality.
+- Preserve Hebrew RTL.
+- Preserve mobile/desktop preview quality.
+- Preserve future editing comfort.
+- Preserve existing worksheet pages.


### PR DESCRIPTION
Draft PR adding a Claude Code command that forces one safest next action only.

Includes only:
- .claude/commands/next.md

No worksheet changes.
No mobile-app changes.
No CSS changes.
No package.json changes.
No scripts/tests changes.
No main push.